### PR TITLE
Allow command-not-found integration with home-manager.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 Weekly updated [nix-index](https://github.com/bennofs/nix-index) database
 
-This repository also provides nixos modules and home-manager modules that adds
-`nix-index` wrapper to uses the database from this repository.
+This repository also provides nixos modules and home-manager modules that add a
+`nix-index` wrapper to use the database from this repository.
+
+The home-manager module also allows integration with the existing `command-not-found`
+functionality.
 
 ## Usage in NixOS
 
@@ -34,12 +37,11 @@ Include the nixos module in your configuration
 1. Follow the [manual](https://github.com/nix-community/home-manager/blob/master/docs/nix-flakes.adoc) to set up home-manager with flakes.
 2. Include the home-manager module in your configuration:
 
-
 ```nix
 {
   inputs = {
     nix-index-database.url = "github:Mic92/nix-index-database";
-    
+
     # Specify the source of Home Manager and Nixpkgs.
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     home-manager = {
@@ -63,6 +65,11 @@ Include the nixos module in your configuration
 
 }
 ```
+
+Additionally, if your shell is managed by home-manager, you can have `nix-index`
+integrate with your shell's `command-not-found` functionality by
+setting `programs.nix-index.enable = true`.
+
 
 ## Ad-hoc download
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1671722432,
+        "narHash": "sha256-ojcZUekIQeOZkHHzR81st7qxX99dB1Eaaq6PU5MNeKc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "652e92b8064949a11bc193b90b74cb727f2a1405",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,31 @@
 {
   description = "nix-index database";
-  outputs = _: let
-    legacyPackages = import ./packages.nix;
-  in {
-    inherit legacyPackages;
 
-    hmModules.nix-index = import ./home-manager-module.nix {
-      inherit legacyPackages;
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs, ... }: with nixpkgs.lib;
+    let
+      systems = attrNames self.legacyPackages;
+
+      packages = genAttrs systems
+        (system: {
+          nix-index-with-db =
+            nixpkgs.legacyPackages.${system}.callPackage ./nix-index-wrapper.nix {
+              nix-index-database = self.legacyPackages.${system}.database;
+            };
+        });
+    in
+    {
+      inherit packages;
+
+      legacyPackages = import ./packages.nix;
+
+      hmModules.nix-index = import ./home-manager-module.nix {
+        inherit packages;
+      };
+
+      nixosModules.nix-index = import ./nixos-module.nix {
+        inherit packages;
+      };
     };
-    nixosModules.nix-index = import ./nixos-module.nix {
-      inherit legacyPackages;
-    };
-  };
 }

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -1,10 +1,9 @@
-{ legacyPackages }:
-{ config, pkgs, inputs, ... }:
+{ packages }:
+{ lib, pkgs, ... }:
 
 {
-  home.packages = [
-    (pkgs.callPackage ./nix-index-wrapper.nix {
-      nix-index-database = legacyPackages.${pkgs.hostPlatform.system}.database;
-    })
-  ];
+  programs.nix-index = {
+    enable = lib.mkDefault true;
+    package = packages.${pkgs.system}.nix-index-with-db;
+  };
 }

--- a/nix-index-wrapper.nix
+++ b/nix-index-wrapper.nix
@@ -1,14 +1,20 @@
 { runCommand
 , makeWrapper
-, nix-index
+, nix-index-unwrapped
 , nix-index-database
 }:
-runCommand "nix-index"
+runCommand "nix-index-with-db"
 {
   nativeBuildInputs = [ makeWrapper ];
 } ''
   mkdir -p $out/share/cache/nix-index
   ln -s ${nix-index-database} $out/share/cache/nix-index/files
-  makeWrapper ${nix-index}/bin/nix-locate $out/bin/nix-locate \
+  makeWrapper ${nix-index-unwrapped}/bin/nix-locate $out/bin/nix-locate \
     --set XDG_CACHE_HOME $out/share/cache
+
+  mkdir --parents $out/etc/profile.d
+  substitute \
+    "${nix-index-unwrapped}/etc/profile.d/command-not-found.sh" \
+    "$out/etc/profile.d/command-not-found.sh" \
+    --replace "${nix-index-unwrapped}" "$out"
 ''

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -1,8 +1,6 @@
-{ legacyPackages }:
-{ config, pkgs, inputs, ... }: {
+{ packages }:
+{ pkgs, ... }: {
   environment.systemPackages = [
-    (pkgs.callPackage ./nix-index-wrapper.nix {
-      nix-index-database = legacyPackages.${pkgs.hostPlatform.system}.database;
-    })
+    packages.${pkgs.system}.nix-index-with-db
   ];
 }


### PR DESCRIPTION
I turned the wrapped packages into native flake outputs, which allows for further flexibility if people want to override additional stuff.

The home-manager module uses the existing nix-index options in home-manager and sets the wrapped package as the main `nix-index` package, which allows the existing `command-not-found` shell integration to work without needing further changes to the user's config. So this flake becomes a drop-in replacement for home-manager users.