### PR TITLE
Symlink prebuilt database to default nix-index location

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
       legacyPackages = import ./packages.nix;
 
       hmModules.nix-index = import ./home-manager-module.nix {
-        inherit packages;
+        inherit (self) packages legacyPackages;
       };
 
       nixosModules.nix-index = import ./nixos-module.nix {

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -1,9 +1,25 @@
-{ packages }:
-{ lib, pkgs, ... }:
+{ packages, legacyPackages }:
+{ lib, pkgs, config, ... }:
 
 {
-  programs.nix-index = {
-    enable = lib.mkDefault true;
-    package = packages.${pkgs.system}.nix-index-with-db;
+  options = {
+    programs.nix-index.symlinkToCacheHome = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to symlink the prebuilt nix-index database to the default
+        location used by nix-index. Useful for tools like comma.
+      '';
+    };
+  };
+  config = {
+    programs.nix-index = {
+      enable = lib.mkDefault true;
+      package = packages.${pkgs.system}.nix-index-with-db;
+    };
+
+    home.file."${config.xdg.cacheHome}/nix-index/files" =
+      lib.mkIf config.programs.nix-index.symlinkToCacheHome
+        { source = legacyPackages.${pkgs.system}.database; };
   };
 }


### PR DESCRIPTION
Closes #33

Feel free to close this if you think this does not fit here, or if there rather first should be a better way to make tools like `comma` use nix-index-database.