### PR TITLE
Use `pkgs.stdenv.system`

### DIFF
--- a/darwin-module.nix
+++ b/darwin-module.nix
@@ -1,5 +1,5 @@
 { packages }:
 { pkgs, ... }: {
   programs.nix-index.enable = true;
-  programs.nix-index.package = packages.${pkgs.system}.nix-index-with-db;
+  programs.nix-index.package = packages.${pkgs.stdenv.system}.nix-index-with-db;
 }

--- a/home-manager-module.nix
+++ b/home-manager-module.nix
@@ -15,11 +15,11 @@
   config = {
     programs.nix-index = {
       enable = lib.mkDefault true;
-      package = packages.${pkgs.system}.nix-index-with-db;
+      package = packages.${pkgs.stdenv.system}.nix-index-with-db;
     };
 
     home.file."${config.xdg.cacheHome}/nix-index/files" =
       lib.mkIf config.programs.nix-index.symlinkToCacheHome
-        { source = legacyPackages.${pkgs.system}.database; };
+        { source = legacyPackages.${pkgs.stdenv.system}.database; };
   };
 }

--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -1,5 +1,5 @@
 { packages }:
 { pkgs, ... }: {
   programs.nix-index.enable = true;
-  programs.nix-index.package = packages.${pkgs.system}.nix-index-with-db;
+  programs.nix-index.package = packages.${pkgs.stdenv.system}.nix-index-with-db;
 }


### PR DESCRIPTION
IIUC, unlike `pkgs.system`, this should always exist.