### PR TITLE
Fix the comma package in nixos-module.nix

### DIFF
--- a/nixos-module.nix
+++ b/nixos-module.nix
@@ -12,6 +12,6 @@
     programs.nix-index.enable = lib.mkDefault true;
     programs.nix-index.package = lib.mkDefault packages.${pkgs.stdenv.system}.nix-index-with-db;
     environment.systemPackages = lib.optional config.programs.nix-index-database.comma.enable 
-      packages.${pkgs.stdenv.system}.nix-index-with-db;
+      packages.${pkgs.stdenv.system}.comma-with-db;
   };
 }


### PR DESCRIPTION
In nixos-module.nix the wrong package is added to `environment.systemPackages` when the comma wrapper is enabled.
This pull request fixes this.