### PR TITLE
Use NIX_INDEX_DATABASE instead of XDG_CACHE_HOME

### DIFF
--- a/nix-index-wrapper.nix
+++ b/nix-index-wrapper.nix
@@ -11,7 +11,7 @@ runCommand "nix-index-with-db-${nix-index-unwrapped.version}"
   mkdir -p $out/share/cache/nix-index
   ln -s ${nix-index-database} $out/share/cache/nix-index/files
   makeWrapper ${nix-index-unwrapped}/bin/nix-locate $out/bin/nix-locate \
-    --set XDG_CACHE_HOME $out/share/cache
+    --set NIX_INDEX_DATABASE $out/share/cache/nix-index
 
   mkdir --parents $out/etc/profile.d
   substitute \


### PR DESCRIPTION
With `nix-index` 0.1.6 in nixpkgs now, we can use `NIX_INDEX_DATABASE` instead of `XDG_CACHE_HOME`, which should unbreak `comma`.

Should fix #48.